### PR TITLE
feature/SCRUM-17--Article

### DIFF
--- a/server/src/main/java/com/example/tiary/TiaryApplication.java
+++ b/server/src/main/java/com/example/tiary/TiaryApplication.java
@@ -2,8 +2,10 @@ package com.example.tiary;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TiaryApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/com/example/tiary/article/controller/ArticleController.java
+++ b/server/src/main/java/com/example/tiary/article/controller/ArticleController.java
@@ -1,0 +1,57 @@
+package com.example.tiary.article.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.tiary.article.dto.request.RequestArticleDto;
+import com.example.tiary.article.service.ArticleService;
+
+@RestController
+@RequestMapping("/article")
+public class ArticleController {
+
+	private final ArticleService articleService;
+
+	public ArticleController(ArticleService articleService) {
+		this.articleService = articleService;
+	}
+
+	//게시물 리스트 조회
+	@GetMapping
+	public ResponseEntity getArticleList() {
+		return new ResponseEntity<>(articleService.readArticleList(), HttpStatus.OK);
+	}
+
+	//게시물 단건 조회
+	@GetMapping("/{article-id}")
+	public ResponseEntity getArticle(@PathVariable("article-id") Long id) {
+		return new ResponseEntity<>(articleService.readArticle(id), HttpStatus.OK);
+	}
+
+	//게시물 등록
+	@PostMapping
+	public ResponseEntity postArticle(@RequestBody RequestArticleDto requestArticleDto) {
+		return new ResponseEntity<>(articleService.createArticle(requestArticleDto), HttpStatus.CREATED);
+	}
+
+	@PatchMapping("/{article-id}")
+	public ResponseEntity patchArticle(@PathVariable("article-id") Long articleId,
+		@RequestBody RequestArticleDto requestArticleDto) {
+		return new ResponseEntity<>(articleService.updateArticle(requestArticleDto, articleId),
+			HttpStatus.RESET_CONTENT);
+	}
+
+	//게시물 삭제
+	@DeleteMapping("/{article-id}")
+	public ResponseEntity deleteArticle(@PathVariable("article-id") Long articleId) {
+		return new ResponseEntity<>(articleService.deleteArticle(articleId), HttpStatus.RESET_CONTENT);
+	}
+}

--- a/server/src/main/java/com/example/tiary/article/dto/request/RequestArticleDto.java
+++ b/server/src/main/java/com/example/tiary/article/dto/request/RequestArticleDto.java
@@ -1,28 +1,32 @@
 package com.example.tiary.article.dto.request;
 
-import java.io.Serializable;
-
 import com.example.tiary.article.entity.Article;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-/**
- * DTO for {@link com.example.tiary.article.entity.Article}
- */
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Builder
-public record RequestArticleDto(
-	@NotNull(message = "제목을 작성해 주세요.") String title,
-	@NotNull String content)
-
-	implements Serializable {
+public class RequestArticleDto {
+	@NotNull(message = "제목을 작성해 주세요.")
+	private String title;
+	@NotNull
+	private String content;
+	private String hashtag;
 
 	public Article toEntity() {
 		return Article.of(
 			null,
 			title,
 			content,
-			1L
+			1L,
+			null
 		);
 	}
 }

--- a/server/src/main/java/com/example/tiary/article/dto/request/RequestArticleDto.java
+++ b/server/src/main/java/com/example/tiary/article/dto/request/RequestArticleDto.java
@@ -1,0 +1,28 @@
+package com.example.tiary.article.dto.request;
+
+import java.io.Serializable;
+
+import com.example.tiary.article.entity.Article;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+/**
+ * DTO for {@link com.example.tiary.article.entity.Article}
+ */
+@Builder
+public record RequestArticleDto(
+	@NotNull(message = "제목을 작성해 주세요.") String title,
+	@NotNull String content)
+
+	implements Serializable {
+
+	public Article toEntity() {
+		return Article.of(
+			null,
+			title,
+			content,
+			1L
+		);
+	}
+}

--- a/server/src/main/java/com/example/tiary/article/dto/response/ResponseArticleDto.java
+++ b/server/src/main/java/com/example/tiary/article/dto/response/ResponseArticleDto.java
@@ -1,0 +1,39 @@
+package com.example.tiary.article.dto.response;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import com.example.tiary.article.entity.Article;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * DTO for {@link com.example.tiary.article.entity.Article}
+ */
+@Builder
+
+public record ResponseArticleDto(
+	Long id,
+	String title,
+	String content,
+	Long view,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt,
+	String createdBy,
+	String modifiedBy
+) implements Serializable {
+
+	public static ResponseArticleDto from(Article article) {
+		return ResponseArticleDto.builder()
+			.id(article.getId())
+			.title(article.getTitle())
+			.content(article.getContent())
+			.view(article.getView())
+			.createdAt(article.getCreatedAt())
+			.modifiedAt(article.getModifiedAt())
+			.createdBy(article.getCreatedBy())
+			.modifiedBy(article.getModifiedBy())
+			.build();
+	}
+}

--- a/server/src/main/java/com/example/tiary/article/dto/response/ResponseArticleDto.java
+++ b/server/src/main/java/com/example/tiary/article/dto/response/ResponseArticleDto.java
@@ -1,30 +1,33 @@
 package com.example.tiary.article.dto.response;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.Hashtag;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-/**
- * DTO for {@link com.example.tiary.article.entity.Article}
- */
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Builder
+public class ResponseArticleDto {
+	private Long id;
+	private String title;
+	private String content;
+	private Long view;
+	private LocalDateTime createdAt;
+	private LocalDateTime modifiedAt;
+	private String createdBy;
+	private String modifiedBy;
+	private List<Hashtag> hashtagList;
 
-public record ResponseArticleDto(
-	Long id,
-	String title,
-	String content,
-	Long view,
-	LocalDateTime createdAt,
-	LocalDateTime modifiedAt,
-	String createdBy,
-	String modifiedBy
-) implements Serializable {
-
-	public static ResponseArticleDto from(Article article) {
+	public static ResponseArticleDto from(Article article, List<Hashtag> hashtagList) {
 		return ResponseArticleDto.builder()
 			.id(article.getId())
 			.title(article.getTitle())
@@ -34,6 +37,7 @@ public record ResponseArticleDto(
 			.modifiedAt(article.getModifiedAt())
 			.createdBy(article.getCreatedBy())
 			.modifiedBy(article.getModifiedBy())
+			.hashtagList(hashtagList)
 			.build();
 	}
 }

--- a/server/src/main/java/com/example/tiary/article/entity/Article.java
+++ b/server/src/main/java/com/example/tiary/article/entity/Article.java
@@ -1,0 +1,31 @@
+package com.example.tiary.article.entity;
+
+import com.example.tiary.global.audit.AuditingFields;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Getter
+@Entity
+public class Article extends AuditingFields {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String title;
+
+	@Column(length = 65554)
+	private String content;
+
+}

--- a/server/src/main/java/com/example/tiary/article/entity/Article.java
+++ b/server/src/main/java/com/example/tiary/article/entity/Article.java
@@ -28,4 +28,17 @@ public class Article extends AuditingFields {
 	@Column(length = 65554)
 	private String content;
 
+	private Long view;
+
+	public static Article of(Long id, String title, String content, Long view) {
+		return new Article(id, title, content, view);
+	}
+
+	public void updateTitle(String title) {
+		this.title = title;
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
 }

--- a/server/src/main/java/com/example/tiary/article/entity/ArticleHashtag.java
+++ b/server/src/main/java/com/example/tiary/article/entity/ArticleHashtag.java
@@ -1,0 +1,32 @@
+package com.example.tiary.article.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Entity
+public class ArticleHashtag {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@ManyToOne
+	@JoinColumn(name = "article_id")
+	private Article article;
+	@ManyToOne
+	@JoinColumn(name = "hashtag_id")
+	private Hashtag hashtag;
+
+	public static ArticleHashtag of(Article article, Hashtag hashtag) {
+		return new ArticleHashtag(null, article, hashtag);
+	}
+}

--- a/server/src/main/java/com/example/tiary/article/entity/Hashtag.java
+++ b/server/src/main/java/com/example/tiary/article/entity/Hashtag.java
@@ -3,8 +3,6 @@ package com.example.tiary.article.entity;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.example.tiary.global.audit.AuditingFields;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -22,28 +20,22 @@ import lombok.ToString;
 @ToString
 @Getter
 @Entity
-public class Article extends AuditingFields {
+public class Hashtag {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	private String title;
 
-	@Column(length = 65554)
-	private String content;
+	@Column(length = 20, unique = true)
+	private String hashtagName;
 
-	private Long view;
-
-	@OneToMany(mappedBy = "article")
+	@OneToMany(mappedBy = "hashtag")
 	@ToString.Exclude
 	private List<ArticleHashtag> articleHashtags = new ArrayList<>();
 
-	public static Article of(Long id, String title, String content, Long view, List<ArticleHashtag> articleHashtags) {
-		return new Article(id, title, content, view, articleHashtags);
+	public static Hashtag of(Long id, String hashtagName, List<ArticleHashtag> articleHashtags) {
+		return new Hashtag(null, hashtagName, articleHashtags);
 	}
-	public void updateTitle(String title) {
-		this.title = title;
-	}
-	public void updateContent(String content) {
-		this.content = content;
+	public static Hashtag of(String hashtagName) {
+		return new Hashtag(null, hashtagName, null);
 	}
 }

--- a/server/src/main/java/com/example/tiary/article/repository/ArticleHashtagRepository.java
+++ b/server/src/main/java/com/example/tiary/article/repository/ArticleHashtagRepository.java
@@ -1,0 +1,12 @@
+package com.example.tiary.article.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.ArticleHashtag;
+
+public interface ArticleHashtagRepository extends JpaRepository<ArticleHashtag, Long> {
+	List<ArticleHashtag> findAllByArticle(Article article);
+}

--- a/server/src/main/java/com/example/tiary/article/repository/ArticleRepository.java
+++ b/server/src/main/java/com/example/tiary/article/repository/ArticleRepository.java
@@ -1,0 +1,8 @@
+package com.example.tiary.article.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.tiary.article.entity.Article;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/server/src/main/java/com/example/tiary/article/repository/HashtagRepository.java
+++ b/server/src/main/java/com/example/tiary/article/repository/HashtagRepository.java
@@ -1,0 +1,9 @@
+package com.example.tiary.article.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.tiary.article.entity.Hashtag;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+	Hashtag findHashtagByHashtagName(String hashtagName);
+}

--- a/server/src/main/java/com/example/tiary/article/service/ArticleService.java
+++ b/server/src/main/java/com/example/tiary/article/service/ArticleService.java
@@ -1,0 +1,27 @@
+package com.example.tiary.article.service;
+
+import java.util.List;
+
+import com.example.tiary.article.dto.request.RequestArticleDto;
+import com.example.tiary.article.dto.response.ResponseArticleDto;
+import com.example.tiary.article.entity.Article;
+
+import jakarta.transaction.Transactional;
+
+public interface ArticleService {
+	// 게시물 조회
+	@org.springframework.transaction.annotation.Transactional(readOnly = true)
+	List<ResponseArticleDto> readArticleList();
+
+	@org.springframework.transaction.annotation.Transactional(readOnly = true)
+	ResponseArticleDto readArticle(Long articleId);
+
+	Article createArticle(RequestArticleDto requestArticleDto);
+
+	// 게시물 수정
+	@Transactional
+	Article updateArticle(RequestArticleDto requestArticleDto, Long articleId);
+
+	@org.springframework.transaction.annotation.Transactional
+	String deleteArticle(Long articleId);
+}

--- a/server/src/main/java/com/example/tiary/article/service/HashtagService.java
+++ b/server/src/main/java/com/example/tiary/article/service/HashtagService.java
@@ -1,0 +1,23 @@
+package com.example.tiary.article.service;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.tiary.article.dto.request.RequestArticleDto;
+import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.Hashtag;
+
+public interface HashtagService {
+	@Transactional
+	List<String> createHashtag(RequestArticleDto requestArticleDto);
+
+	@Transactional
+	Boolean saveHashtag(List<String> hashtagList, Article article);
+
+	@Transactional
+	Boolean updateHashtag(List<String> hashList, Article article);
+
+	@Transactional
+	void removeOldHashtag(Article article);
+}

--- a/server/src/main/java/com/example/tiary/article/service/impl/ArticleServiceImpl.java
+++ b/server/src/main/java/com/example/tiary/article/service/impl/ArticleServiceImpl.java
@@ -9,24 +9,38 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.tiary.article.dto.request.RequestArticleDto;
 import com.example.tiary.article.dto.response.ResponseArticleDto;
 import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.repository.ArticleHashtagRepository;
 import com.example.tiary.article.repository.ArticleRepository;
 import com.example.tiary.article.service.ArticleService;
+import com.example.tiary.article.service.HashtagService;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 public class ArticleServiceImpl implements ArticleService {
 	private final ArticleRepository articleRepository;
+	private final ArticleHashtagRepository articleHashtagRepository;
+	private final HashtagService hashtagService;
 
-	public ArticleServiceImpl(ArticleRepository articleRepository) {
+	public ArticleServiceImpl(ArticleRepository articleRepository, ArticleHashtagRepository articleHashtagRepository,
+		HashtagService hashtagService) {
 		this.articleRepository = articleRepository;
+		this.articleHashtagRepository = articleHashtagRepository;
+		this.hashtagService = hashtagService;
 	}
 
 	// 게시물 조회
 	@Transactional(readOnly = true)
 	@Override
 	public List<ResponseArticleDto> readArticleList() {
-		return articleRepository.findAll().stream().map(ResponseArticleDto::from).toList();
+		List<Article> articles = articleRepository.findAll();
+
+		// return articles.stream()
+		// 	.map(article -> ResponseArticleDto.from(article,
+		// 		hashtagRepository.findAllBy(article.getId()))).toList();
+		return null;
 	}
 
 	//게시물 단건 조회
@@ -35,15 +49,24 @@ public class ArticleServiceImpl implements ArticleService {
 	@Override
 	public ResponseArticleDto readArticle(Long articleId) {
 
-		return ResponseArticleDto.from(articleRepository.findById(articleId)
-			.orElseThrow(() -> new EntityNotFoundException("게시물이 존재하지 않습니다.")));
+		Article article = articleRepository.findById(articleId)
+			.orElseThrow(() -> new EntityNotFoundException("게시물이 존재하지 않습니다."));
+
+		// ResponseArticleDto responseArticleDto = ResponseArticleDto.from(article, hashtagRepository.findAllByArticleId(article.getId()))
+
+		return null;
 	}
 
 	// 게시물 생성
+	//TODO DB 최적화 고민
 	@Transactional
 	@Override
 	public Article createArticle(RequestArticleDto requestArticleDto) {
-		return articleRepository.save(requestArticleDto.toEntity());
+
+		Article article = articleRepository.saveAndFlush(requestArticleDto.toEntity());
+		hashtagService.saveHashtag(hashtagService.createHashtag(requestArticleDto), article);
+
+		return article;
 	}
 
 	// 게시물 수정
@@ -53,8 +76,12 @@ public class ArticleServiceImpl implements ArticleService {
 		Article article = articleRepository.findById(articleId)
 			.orElseThrow(() -> new EntityNotFoundException("게시물이 존재하지 않습니다."));
 
-		Optional.ofNullable(requestArticleDto.title()).ifPresent(article::updateTitle);
-		Optional.ofNullable(requestArticleDto.content()).ifPresent(article::updateContent);
+		Optional.ofNullable(requestArticleDto.getTitle()).ifPresent(article::updateTitle);
+		Optional.ofNullable(requestArticleDto.getContent()).ifPresent(article::updateContent);
+
+		hashtagService.removeOldHashtag(article);
+		hashtagService.updateHashtag(hashtagService.createHashtag(requestArticleDto), article);
+
 		return articleRepository.save(article);
 	}
 

--- a/server/src/main/java/com/example/tiary/article/service/impl/ArticleServiceImpl.java
+++ b/server/src/main/java/com/example/tiary/article/service/impl/ArticleServiceImpl.java
@@ -1,0 +1,71 @@
+package com.example.tiary.article.service.impl;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.tiary.article.dto.request.RequestArticleDto;
+import com.example.tiary.article.dto.response.ResponseArticleDto;
+import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.repository.ArticleRepository;
+import com.example.tiary.article.service.ArticleService;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@Service
+public class ArticleServiceImpl implements ArticleService {
+	private final ArticleRepository articleRepository;
+
+	public ArticleServiceImpl(ArticleRepository articleRepository) {
+		this.articleRepository = articleRepository;
+	}
+
+	// 게시물 조회
+	@Transactional(readOnly = true)
+	@Override
+	public List<ResponseArticleDto> readArticleList() {
+		return articleRepository.findAll().stream().map(ResponseArticleDto::from).toList();
+	}
+
+	//게시물 단건 조회
+
+	@Transactional(readOnly = true)
+	@Override
+	public ResponseArticleDto readArticle(Long articleId) {
+
+		return ResponseArticleDto.from(articleRepository.findById(articleId)
+			.orElseThrow(() -> new EntityNotFoundException("게시물이 존재하지 않습니다.")));
+	}
+
+	// 게시물 생성
+	@Transactional
+	@Override
+	public Article createArticle(RequestArticleDto requestArticleDto) {
+		return articleRepository.save(requestArticleDto.toEntity());
+	}
+
+	// 게시물 수정
+	@Transactional
+	@Override
+	public Article updateArticle(RequestArticleDto requestArticleDto, Long articleId) {
+		Article article = articleRepository.findById(articleId)
+			.orElseThrow(() -> new EntityNotFoundException("게시물이 존재하지 않습니다."));
+
+		Optional.ofNullable(requestArticleDto.title()).ifPresent(article::updateTitle);
+		Optional.ofNullable(requestArticleDto.content()).ifPresent(article::updateContent);
+		return articleRepository.save(article);
+	}
+
+	//게시물 삭제
+	@Transactional
+	@Override
+	public String deleteArticle(Long articleId) {
+		Article article = articleRepository.findById(articleId)
+			.orElseThrow(() -> new EntityNotFoundException("게시물이 이미 삭제 되었습니다."));
+
+		articleRepository.delete(article);
+		return "삭제 완료";
+	}
+}

--- a/server/src/main/java/com/example/tiary/article/service/impl/HashtagServiceImpl.java
+++ b/server/src/main/java/com/example/tiary/article/service/impl/HashtagServiceImpl.java
@@ -1,0 +1,85 @@
+package com.example.tiary.article.service.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.tiary.article.dto.request.RequestArticleDto;
+import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.ArticleHashtag;
+import com.example.tiary.article.entity.Hashtag;
+import com.example.tiary.article.repository.ArticleHashtagRepository;
+import com.example.tiary.article.repository.HashtagRepository;
+import com.example.tiary.article.service.HashtagService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class HashtagServiceImpl implements HashtagService {
+
+	private final HashtagRepository hashtagRepository;
+	private final ArticleHashtagRepository articleHashtagRepository;
+
+	public HashtagServiceImpl(HashtagRepository hashtagRepository, ArticleHashtagRepository articleHashtagRepository) {
+		this.hashtagRepository = hashtagRepository;
+		this.articleHashtagRepository = articleHashtagRepository;
+	}
+
+
+	// 해시태그 가공
+	@Override
+	public List<String> createHashtag(RequestArticleDto requestArticleDto) {
+
+		Pattern HASHTAG_PATTERN = Pattern.compile("#(\\S+)");
+		Matcher matcher = HASHTAG_PATTERN.matcher(requestArticleDto.getHashtag());
+		List<String> hashtagList = new ArrayList<>();
+
+		while (matcher.find()) {
+			hashtagList.add((matcher.group(1)));
+		}
+		return hashtagList;
+	}
+
+	//해시태그 저장
+	@Transactional
+	@Override
+	public Boolean saveHashtag(List<String> hashtagList, Article article) {
+		for (String tag : hashtagList) {
+			Hashtag hashtag = hashtagRepository.findHashtagByHashtagName(tag);
+			if (hashtag == null) {
+				hashtag = Hashtag.of(tag);
+				hashtagRepository.save(hashtag);
+			}
+			articleHashtagRepository.save(ArticleHashtag.of(article, hashtag));
+		}
+		return true;
+	}
+
+	@Transactional
+	@Override
+	public Boolean updateHashtag(List<String> hashList, Article article) {
+
+		for(String tag: hashList){
+			Hashtag hashtag = hashtagRepository.findHashtagByHashtagName(tag);
+			if(hashtag == null){
+				hashtag = Hashtag.of(tag);
+				hashtagRepository.save(hashtag);
+			}
+			articleHashtagRepository.save(ArticleHashtag.of(article, hashtag));
+		}
+		log.info("수정 조인 테이블 확인 : {}" );
+		return true;
+	}
+
+	@Transactional
+	@Override
+	public void removeOldHashtag(Article article){
+		List<ArticleHashtag> articleHashtag = articleHashtagRepository.findAllByArticle(article);
+		articleHashtagRepository.deleteAll(articleHashtag);
+	}
+}

--- a/server/src/main/java/com/example/tiary/global/audit/AuditingFields.java
+++ b/server/src/main/java/com/example/tiary/global/audit/AuditingFields.java
@@ -1,0 +1,41 @@
+package com.example.tiary.global.audit;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@ToString
+@MappedSuperclass
+public abstract class AuditingFields {
+
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	@CreatedDate
+	@Column(nullable = true, updatable = false)
+	private LocalDateTime createdAt; //생성일시
+
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	@LastModifiedDate
+	@Column(nullable = true)
+	private LocalDateTime modifiedAt; //수정일시
+
+	@CreatedBy
+	@Column(nullable = true)
+	private String createdBy; // 생성자
+
+	@LastModifiedBy
+	@Column(nullable = true)
+	private String modifiedBy; // 수정자
+}


### PR DESCRIPTION
## Article 기본적인 구현


- [x] CRUD 구현
- [x] AuditingFields 생성
- [x] `DTO` 는 불변객체인 `record` 활용하여 구현 -> `@Getter`, `@Setter` 필요없음

```java
 // record의 값 가져오는 방법

//e.g.,

public record RequestArticleDto(
	@NotNull(message = "제목을 작성해 주세요.") String title,
	@NotNull String content)

	implements Serializable {

	public Article toEntity() {
		return Article.of(
			null,
			title,
			content,
			1L
		);
	}
}

// RequestArticleDto.title

```

---

## Hashtag 구현

- #2 

- 해시태그 다중 선택은 추후 구현 예정