### PR TITLE
feature/SCRUM-54--Hashtag

### DIFF
--- a/server/src/main/java/com/example/tiary/article/dto/request/RequestArticleDto.java
+++ b/server/src/main/java/com/example/tiary/article/dto/request/RequestArticleDto.java
@@ -1,28 +1,36 @@
 package com.example.tiary.article.dto.request;
 
 import java.io.Serializable;
+import java.util.List;
 
 import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.Hashtag;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-/**
- * DTO for {@link com.example.tiary.article.entity.Article}
- */
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Builder
-public record RequestArticleDto(
-	@NotNull(message = "제목을 작성해 주세요.") String title,
-	@NotNull String content)
-
-	implements Serializable {
+public class RequestArticleDto {
+	@NotNull(message = "제목을 작성해 주세요.")
+	private String title;
+	@NotNull
+	private String content;
+	private String hashtag;
 
 	public Article toEntity() {
 		return Article.of(
 			null,
 			title,
 			content,
-			1L
+			1L,
+			null
 		);
 	}
 }

--- a/server/src/main/java/com/example/tiary/article/dto/request/RequestArticleDto.java
+++ b/server/src/main/java/com/example/tiary/article/dto/request/RequestArticleDto.java
@@ -1,10 +1,6 @@
 package com.example.tiary.article.dto.request;
 
-import java.io.Serializable;
-import java.util.List;
-
 import com.example.tiary.article.entity.Article;
-import com.example.tiary.article.entity.Hashtag;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;

--- a/server/src/main/java/com/example/tiary/article/dto/response/ResponseArticleDto.java
+++ b/server/src/main/java/com/example/tiary/article/dto/response/ResponseArticleDto.java
@@ -1,6 +1,5 @@
 package com.example.tiary.article.dto.response;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/server/src/main/java/com/example/tiary/article/dto/response/ResponseArticleDto.java
+++ b/server/src/main/java/com/example/tiary/article/dto/response/ResponseArticleDto.java
@@ -2,29 +2,33 @@ package com.example.tiary.article.dto.response;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.Hashtag;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-/**
- * DTO for {@link com.example.tiary.article.entity.Article}
- */
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Builder
+public class ResponseArticleDto {
+	private Long id;
+	private String title;
+	private String content;
+	private Long view;
+	private LocalDateTime createdAt;
+	private LocalDateTime modifiedAt;
+	private String createdBy;
+	private String modifiedBy;
+	private List<Hashtag> hashtagList;
 
-public record ResponseArticleDto(
-	Long id,
-	String title,
-	String content,
-	Long view,
-	LocalDateTime createdAt,
-	LocalDateTime modifiedAt,
-	String createdBy,
-	String modifiedBy
-) implements Serializable {
-
-	public static ResponseArticleDto from(Article article) {
+	public static ResponseArticleDto from(Article article, List<Hashtag> hashtagList) {
 		return ResponseArticleDto.builder()
 			.id(article.getId())
 			.title(article.getTitle())
@@ -34,6 +38,7 @@ public record ResponseArticleDto(
 			.modifiedAt(article.getModifiedAt())
 			.createdBy(article.getCreatedBy())
 			.modifiedBy(article.getModifiedBy())
+			.hashtagList(hashtagList)
 			.build();
 	}
 }

--- a/server/src/main/java/com/example/tiary/article/entity/Article.java
+++ b/server/src/main/java/com/example/tiary/article/entity/Article.java
@@ -1,5 +1,8 @@
 package com.example.tiary.article.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.example.tiary.global.audit.AuditingFields;
 
 import jakarta.persistence.Column;
@@ -7,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,8 +34,11 @@ public class Article extends AuditingFields {
 
 	private Long view;
 
-	public static Article of(Long id, String title, String content, Long view) {
-		return new Article(id, title, content, view);
+	@OneToMany(mappedBy = "article")
+	private List<ArticleHashtag> articleHashtags = new ArrayList<>();
+
+	public static Article of(Long id, String title, String content, Long view, List<ArticleHashtag> articleHashtags) {
+		return new Article(id, title, content, view,articleHashtags);
 	}
 
 	public void updateTitle(String title) {

--- a/server/src/main/java/com/example/tiary/article/entity/Article.java
+++ b/server/src/main/java/com/example/tiary/article/entity/Article.java
@@ -23,7 +23,6 @@ import lombok.ToString;
 @Getter
 @Entity
 public class Article extends AuditingFields {
-
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -35,16 +34,15 @@ public class Article extends AuditingFields {
 	private Long view;
 
 	@OneToMany(mappedBy = "article")
+	@ToString.Exclude
 	private List<ArticleHashtag> articleHashtags = new ArrayList<>();
 
 	public static Article of(Long id, String title, String content, Long view, List<ArticleHashtag> articleHashtags) {
-		return new Article(id, title, content, view,articleHashtags);
+		return new Article(id, title, content, view, articleHashtags);
 	}
-
 	public void updateTitle(String title) {
 		this.title = title;
 	}
-
 	public void updateContent(String content) {
 		this.content = content;
 	}

--- a/server/src/main/java/com/example/tiary/article/entity/ArticleHashtag.java
+++ b/server/src/main/java/com/example/tiary/article/entity/ArticleHashtag.java
@@ -9,9 +9,11 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 @Entity
 public class ArticleHashtag {
 	@Id
@@ -24,7 +26,7 @@ public class ArticleHashtag {
 	@JoinColumn(name = "hashtag_id")
 	private Hashtag hashtag;
 
-	public static ArticleHashtag of(Article article, Hashtag hashtag){
-		return new ArticleHashtag(null,article, hashtag);
+	public static ArticleHashtag of(Article article, Hashtag hashtag) {
+		return new ArticleHashtag(null, article, hashtag);
 	}
 }

--- a/server/src/main/java/com/example/tiary/article/entity/ArticleHashtag.java
+++ b/server/src/main/java/com/example/tiary/article/entity/ArticleHashtag.java
@@ -1,0 +1,30 @@
+package com.example.tiary.article.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ArticleHashtag {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@ManyToOne
+	@JoinColumn(name = "article_id")
+	private Article article;
+	@ManyToOne
+	@JoinColumn(name = "hashtag_id")
+	private Hashtag hashtag;
+
+	public static ArticleHashtag of(Article article, Hashtag hashtag){
+		return new ArticleHashtag(null,article, hashtag);
+	}
+}

--- a/server/src/main/java/com/example/tiary/article/entity/Hashtag.java
+++ b/server/src/main/java/com/example/tiary/article/entity/Hashtag.java
@@ -13,9 +13,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 @Getter
 @Entity
 public class Hashtag {
@@ -23,21 +25,17 @@ public class Hashtag {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(length = 20)
+	@Column(length = 20, unique = true)
 	private String hashtagName;
 
 	@OneToMany(mappedBy = "hashtag")
-	private List<ArticleHashtag> articleHashtags  = new ArrayList<>();
+	@ToString.Exclude
+	private List<ArticleHashtag> articleHashtags = new ArrayList<>();
 
 	public static Hashtag of(Long id, String hashtagName, List<ArticleHashtag> articleHashtags) {
 		return new Hashtag(null, hashtagName, articleHashtags);
 	}
-
 	public static Hashtag of(String hashtagName) {
-		return new Hashtag(null, hashtagName,null);
-	}
-
-	public void updateHashtagName(String hashtagName) {
-		this.hashtagName = hashtagName;
+		return new Hashtag(null, hashtagName, null);
 	}
 }

--- a/server/src/main/java/com/example/tiary/article/entity/Hashtag.java
+++ b/server/src/main/java/com/example/tiary/article/entity/Hashtag.java
@@ -1,0 +1,43 @@
+package com.example.tiary.article.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Hashtag {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 20)
+	private String hashtagName;
+
+	@OneToMany(mappedBy = "hashtag")
+	private List<ArticleHashtag> articleHashtags  = new ArrayList<>();
+
+	public static Hashtag of(Long id, String hashtagName, List<ArticleHashtag> articleHashtags) {
+		return new Hashtag(null, hashtagName, articleHashtags);
+	}
+
+	public static Hashtag of(String hashtagName) {
+		return new Hashtag(null, hashtagName,null);
+	}
+
+	public void updateHashtagName(String hashtagName) {
+		this.hashtagName = hashtagName;
+	}
+}

--- a/server/src/main/java/com/example/tiary/article/repository/ArticleHashtagRepository.java
+++ b/server/src/main/java/com/example/tiary/article/repository/ArticleHashtagRepository.java
@@ -1,8 +1,12 @@
 package com.example.tiary.article.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.example.tiary.article.entity.Article;
 import com.example.tiary.article.entity.ArticleHashtag;
 
 public interface ArticleHashtagRepository extends JpaRepository<ArticleHashtag, Long> {
+	List<ArticleHashtag> findAllByArticle(Article article);
 }

--- a/server/src/main/java/com/example/tiary/article/repository/ArticleHashtagRepository.java
+++ b/server/src/main/java/com/example/tiary/article/repository/ArticleHashtagRepository.java
@@ -1,0 +1,8 @@
+package com.example.tiary.article.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.tiary.article.entity.ArticleHashtag;
+
+public interface ArticleHashtagRepository extends JpaRepository<ArticleHashtag, Long> {
+}

--- a/server/src/main/java/com/example/tiary/article/repository/HashtagRepository.java
+++ b/server/src/main/java/com/example/tiary/article/repository/HashtagRepository.java
@@ -1,0 +1,9 @@
+package com.example.tiary.article.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.tiary.article.entity.Hashtag;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+	Hashtag findHashtagByHashtagName(String hashtagName);
+}

--- a/server/src/main/java/com/example/tiary/article/service/HashtagService.java
+++ b/server/src/main/java/com/example/tiary/article/service/HashtagService.java
@@ -1,0 +1,16 @@
+package com.example.tiary.article.service;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.tiary.article.dto.request.RequestArticleDto;
+import com.example.tiary.article.entity.Article;
+
+public interface HashtagService {
+	@Transactional
+	List<String> createHashtag(RequestArticleDto requestArticleDto);
+
+	@Transactional
+	Boolean saveHashtag(List<String> hashtagList, Article article);
+}

--- a/server/src/main/java/com/example/tiary/article/service/HashtagService.java
+++ b/server/src/main/java/com/example/tiary/article/service/HashtagService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.tiary.article.dto.request.RequestArticleDto;
 import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.Hashtag;
 
 public interface HashtagService {
 	@Transactional
@@ -13,4 +14,10 @@ public interface HashtagService {
 
 	@Transactional
 	Boolean saveHashtag(List<String> hashtagList, Article article);
+
+	@Transactional
+	Boolean updateHashtag(List<String> hashList, Article article);
+
+	@Transactional
+	void removeOldHashtag(Article article);
 }

--- a/server/src/main/java/com/example/tiary/article/service/impl/ArticleServiceImpl.java
+++ b/server/src/main/java/com/example/tiary/article/service/impl/ArticleServiceImpl.java
@@ -9,8 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.tiary.article.dto.request.RequestArticleDto;
 import com.example.tiary.article.dto.response.ResponseArticleDto;
 import com.example.tiary.article.entity.Article;
-import com.example.tiary.article.entity.ArticleHashtag;
-import com.example.tiary.article.entity.Hashtag;
 import com.example.tiary.article.repository.ArticleHashtagRepository;
 import com.example.tiary.article.repository.ArticleRepository;
 import com.example.tiary.article.service.ArticleService;
@@ -66,7 +64,7 @@ public class ArticleServiceImpl implements ArticleService {
 	public Article createArticle(RequestArticleDto requestArticleDto) {
 
 		Article article = articleRepository.saveAndFlush(requestArticleDto.toEntity());
-		hashtagService.saveHashtag(hashtagService.createHashtag(requestArticleDto),article);
+		hashtagService.saveHashtag(hashtagService.createHashtag(requestArticleDto), article);
 
 		return article;
 	}
@@ -80,6 +78,9 @@ public class ArticleServiceImpl implements ArticleService {
 
 		Optional.ofNullable(requestArticleDto.getTitle()).ifPresent(article::updateTitle);
 		Optional.ofNullable(requestArticleDto.getContent()).ifPresent(article::updateContent);
+
+		hashtagService.removeOldHashtag(article);
+		hashtagService.updateHashtag(hashtagService.createHashtag(requestArticleDto), article);
 
 		return articleRepository.save(article);
 	}

--- a/server/src/main/java/com/example/tiary/article/service/impl/ArticleServiceImpl.java
+++ b/server/src/main/java/com/example/tiary/article/service/impl/ArticleServiceImpl.java
@@ -9,24 +9,40 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.tiary.article.dto.request.RequestArticleDto;
 import com.example.tiary.article.dto.response.ResponseArticleDto;
 import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.ArticleHashtag;
+import com.example.tiary.article.entity.Hashtag;
+import com.example.tiary.article.repository.ArticleHashtagRepository;
 import com.example.tiary.article.repository.ArticleRepository;
 import com.example.tiary.article.service.ArticleService;
+import com.example.tiary.article.service.HashtagService;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 public class ArticleServiceImpl implements ArticleService {
 	private final ArticleRepository articleRepository;
+	private final ArticleHashtagRepository articleHashtagRepository;
+	private final HashtagService hashtagService;
 
-	public ArticleServiceImpl(ArticleRepository articleRepository) {
+	public ArticleServiceImpl(ArticleRepository articleRepository, ArticleHashtagRepository articleHashtagRepository,
+		HashtagService hashtagService) {
 		this.articleRepository = articleRepository;
+		this.articleHashtagRepository = articleHashtagRepository;
+		this.hashtagService = hashtagService;
 	}
 
 	// 게시물 조회
 	@Transactional(readOnly = true)
 	@Override
 	public List<ResponseArticleDto> readArticleList() {
-		return articleRepository.findAll().stream().map(ResponseArticleDto::from).toList();
+		List<Article> articles = articleRepository.findAll();
+
+		// return articles.stream()
+		// 	.map(article -> ResponseArticleDto.from(article,
+		// 		hashtagRepository.findAllBy(article.getId()))).toList();
+		return null;
 	}
 
 	//게시물 단건 조회
@@ -35,15 +51,24 @@ public class ArticleServiceImpl implements ArticleService {
 	@Override
 	public ResponseArticleDto readArticle(Long articleId) {
 
-		return ResponseArticleDto.from(articleRepository.findById(articleId)
-			.orElseThrow(() -> new EntityNotFoundException("게시물이 존재하지 않습니다.")));
+		Article article = articleRepository.findById(articleId)
+			.orElseThrow(() -> new EntityNotFoundException("게시물이 존재하지 않습니다."));
+
+		// ResponseArticleDto responseArticleDto = ResponseArticleDto.from(article, hashtagRepository.findAllByArticleId(article.getId()))
+
+		return null;
 	}
 
 	// 게시물 생성
+	//TODO DB 최적화 고민
 	@Transactional
 	@Override
 	public Article createArticle(RequestArticleDto requestArticleDto) {
-		return articleRepository.save(requestArticleDto.toEntity());
+
+		Article article = articleRepository.saveAndFlush(requestArticleDto.toEntity());
+		hashtagService.saveHashtag(hashtagService.createHashtag(requestArticleDto),article);
+
+		return article;
 	}
 
 	// 게시물 수정
@@ -53,8 +78,9 @@ public class ArticleServiceImpl implements ArticleService {
 		Article article = articleRepository.findById(articleId)
 			.orElseThrow(() -> new EntityNotFoundException("게시물이 존재하지 않습니다."));
 
-		Optional.ofNullable(requestArticleDto.title()).ifPresent(article::updateTitle);
-		Optional.ofNullable(requestArticleDto.content()).ifPresent(article::updateContent);
+		Optional.ofNullable(requestArticleDto.getTitle()).ifPresent(article::updateTitle);
+		Optional.ofNullable(requestArticleDto.getContent()).ifPresent(article::updateContent);
+
 		return articleRepository.save(article);
 	}
 

--- a/server/src/main/java/com/example/tiary/article/service/impl/HashtagServiceImpl.java
+++ b/server/src/main/java/com/example/tiary/article/service/impl/HashtagServiceImpl.java
@@ -1,0 +1,58 @@
+package com.example.tiary.article.service.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.tiary.article.dto.request.RequestArticleDto;
+import com.example.tiary.article.entity.Article;
+import com.example.tiary.article.entity.ArticleHashtag;
+import com.example.tiary.article.entity.Hashtag;
+import com.example.tiary.article.repository.ArticleHashtagRepository;
+import com.example.tiary.article.repository.HashtagRepository;
+import com.example.tiary.article.service.HashtagService;
+@Service
+public class HashtagServiceImpl implements HashtagService {
+
+	private final HashtagRepository hashtagRepository;
+	private final ArticleHashtagRepository articleHashtagRepository;
+
+	public HashtagServiceImpl(HashtagRepository hashtagRepository, ArticleHashtagRepository articleHashtagRepository) {
+		this.hashtagRepository = hashtagRepository;
+		this.articleHashtagRepository = articleHashtagRepository;
+	}
+
+	// 해시태그 가공
+	@Override
+	public List<String> createHashtag(RequestArticleDto requestArticleDto) {
+
+		Pattern HASHTAG_PATTERN = Pattern.compile("#(\\S+)");
+		Matcher matcher = HASHTAG_PATTERN.matcher(requestArticleDto.getHashtag());
+		List<String> hashtagList = new ArrayList<>();
+
+		while(matcher.find()){
+			hashtagList.add((matcher.group(1)));
+		}
+		return hashtagList;
+	}
+
+	//해시태그 저장
+	@Transactional
+	@Override
+	public Boolean saveHashtag(List<String> hashtagList, Article article){
+		for(String tag : hashtagList){
+			Hashtag hashtag = hashtagRepository.findHashtagByHashtagName(tag);
+			if(hashtag == null){
+				hashtag = Hashtag.of(tag);
+				hashtagRepository.saveAndFlush(hashtag);
+			}
+			articleHashtagRepository.saveAndFlush(ArticleHashtag.of(article, hashtag));
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
# Parent 
- #1  

## 해시태그 구현
- 해시태그 구현을 위해 `다대다` 연관관계가 필요하여 조인테이블 생성
- **해시태그 수정 시 DB의 `id` 값을 증가 시키고 싶지 않아 정보를 변경하는 것으로 했는데 이슈가 있어 이전 데이터를 지우고 새로 만드는 방법으로 변경**

---
ISSUE.
## ID 증가 vs. 무결성 유지:

> ID가 계속 증가하는 방식은 일반적으로 관계형 데이터베이스의 기본 동작입니다. 이는 데이터베이스가 일정한 규칙에 따라 데이터를 쉽게 식별하고 관리할 수 있도록 도와줍니다. 이러한 방식은 대부분의 상황에서 잘 동작하며 데이터베이스의 무결성을 강화할 수 있습니다.
하지만 특정 요구사항이나 제약 사항으로 인해 ID가 계속 증가하는 방식이 적합하지 않는 경우도 있습니다. 이 경우에는 무결성 유지를 중시하고자 할 수 있습니다.

1. 무결성 유지의 장점:

특별한 비즈니스 요구사항이나 제약 사항이 있을 때, 무결성을 유지하는 것이 더 적절할 수 있습니다. 예를 들어, 특정 과목이나 학생에 대한 고유한 식별자를 유지하려는 경우입니다.
데이터의 특성이나 비즈니스 규칙이 ID 증가 방식을 사용하기 어렵게 만들 경우, 무결성 유지가 더 적절할 수 있습니다.

2. ID 재사용 문제:

ID를 변경하는 방식에서는 주의해야 할 점 중 하나는 ID를 재사용할 때 발생하는 문제입니다. 만약 이전 과목을 삭제하지 않고 업데이트하는 방식을 사용하면, 동일한 ID를 가진 다른 학생의 과목 정보가 변경될 수 있습니다.

3.비즈니스 요구사항:

가장 중요한 것은 비즈니스 요구사항과 데이터 모델에 따라서 어떤 방식이 더 적절한지를 고려하는 것입니다. 비즈니스 요구사항이나 특별한 제약에 따라 다른 방식을 선택할 수 있습니다.


